### PR TITLE
docs: fix minor typos

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -47,7 +47,7 @@ After initialization and loading initial data, the script runs Alembic migration
 
 ## Contributing
 
-To contirbute to the database schema:
+To contribute to the database schema:
 
 1. Make a change in the [models](../core/models/__init__.py) file
 2. Generate a new migration script: `alembic revision --autogenerate "Description"`

--- a/core/README.md
+++ b/core/README.md
@@ -1,7 +1,7 @@
 # Core Tools for CHAI Python Loaders
 
 This directory contains a set of core tools and utilities to facilitate loading the CHAI
-database with packaage manager data, using python helpers. These tools provide a common
+database with package manager data, using python helpers. These tools provide a common
 foundation for fetching, transforming, and loading data from various package managers
 into the database.
 


### PR DESCRIPTION
Fixed a few typos to make the documentation clearer. Hope this helps.