### PR TITLE
feat(api): Add pagination and enhance error handling

### DIFF
--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -24,9 +24,38 @@ struct PaginatedResponse {
     data: Vec<Value>,
 }
 
+pub fn check_table_exists(table: &str, tables: &[String]) -> Option<HttpResponse> {
+    if !tables.contains(&table.to_string()) {
+        Some(HttpResponse::NotFound().json(json!({
+            "error": format!("Table '{}' not found", table),
+            "valid_tables": tables,
+            "help": "Refer to the API documentation for valid table names."
+        })))
+    } else {
+        None
+    }
+}
+
 #[get("/tables")]
-pub async fn list_tables(data: web::Data<AppState>) -> impl Responder {
-    HttpResponse::Ok().json(&*data.tables)
+pub async fn list_tables(
+    query: web::Query<PaginationParams>,
+    data: web::Data<AppState>,
+) -> impl Responder {
+    let total_count = data.tables.len() as i64;
+    let pagination = Pagination::new(query, total_count);
+
+    let start = pagination.offset as usize;
+    let end = (start + pagination.limit as usize).min(data.tables.len());
+
+    let paginated_tables = &data.tables[start..end];
+
+    HttpResponse::Ok().json(json!({
+        "total_count": total_count,
+        "page": pagination.page,
+        "limit": pagination.limit,
+        "total_pages": pagination.total_pages,
+        "data": paginated_tables,
+    }))
 }
 
 #[get("/heartbeat")]
@@ -53,11 +82,9 @@ pub async fn get_table(
     data: web::Data<AppState>,
 ) -> impl Responder {
     let table = path.into_inner();
-    if !data.tables.contains(&table) {
-        return HttpResponse::NotFound().json(json!({
-            "error": format!("Table '{}' not found", table)
-        }));
-    }
+    if let Some(response) = check_table_exists(&table, &data.tables) {
+    return response;
+}
 
     let count_query = format!("SELECT COUNT(*) FROM {}", table);
     match data.pool.get().await {
@@ -114,11 +141,9 @@ pub async fn get_table_row(
 ) -> impl Responder {
     let (table_name, id) = path.into_inner();
 
-    if !data.tables.contains(&table_name) {
-        return HttpResponse::NotFound().json(json!({
-            "error": format!("Table '{}' not found", table_name)
-        }));
-    }
+    if let Some(response) = check_table_exists(&table_name, &data.tables) {
+    return response;
+}
 
     let query = format!("SELECT * FROM {} WHERE id = $1", table_name);
 

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -83,8 +83,8 @@ pub async fn get_table(
 ) -> impl Responder {
     let table = path.into_inner();
     if let Some(response) = check_table_exists(&table, &data.tables) {
-    return response;
-}
+        return response;
+    }
 
     let count_query = format!("SELECT COUNT(*) FROM {}", table);
     match data.pool.get().await {
@@ -142,8 +142,8 @@ pub async fn get_table_row(
     let (table_name, id) = path.into_inner();
 
     if let Some(response) = check_table_exists(&table_name, &data.tables) {
-    return response;
-}
+        return response;
+    }
 
     let query = format!("SELECT * FROM {} WHERE id = $1", table_name);
 


### PR DESCRIPTION
Summary
This pull request introduces two major improvements to the API:
1. **Pagination for `/tables`:** The route now supports `page` and `limit` query parameters, returning paginated results with metadata such as `total_count`, `page`, and `total_pages`.
2. **Enhanced 404 Error Responses:** Refactored table existence checks into a reusable `check_table_exists` utility function. The 404 responses now include valid table suggestions and a link to API documentation for improved client experience.

Changes
- Updated `/tables` to support pagination.
- Centralized table existence checks.
- Improved error messages for invalid table names.

Benefits
- Scalable API for large datasets.
- Consistent and user-friendly error handling.