### PR TITLE
fix: Add error handling for database connection

### DIFF
--- a/examples/visualizer/main.py
+++ b/examples/visualizer/main.py
@@ -87,8 +87,14 @@ class DB:
         )
 
     def connect(self) -> None:
-        self.conn = psycopg2.connect(CHAI_DATABASE_URL)
-        self.cursor = self.conn.cursor()
+        if not CHAI_DATABASE_URL:
+            raise RuntimeError("Environment variable CHAI_DATABASE_URL is not set.")
+            
+        try:
+            self.conn = psycopg2.connect(CHAI_DATABASE_URL)
+            self.cursor = self.conn.cursor()
+        except psycopg2.OperationalError as e:
+            raise RuntimeError(f"Failed to connect to the database: {e}")
 
     def select_id(self, package: str) -> int:
         self.cursor.execute("EXECUTE select_id (%s)", (package,))


### PR DESCRIPTION
### Summary
Adds error handling for database connections in the `DB` class in `examples/visualizer/main.py`.
Validates the presence of the `CHAI_DATABASE_URL` environment variable before attempting a connection.
Wraps the `psycopg2.connect` call in a `try-except` block to provide meaningful error messages when a connection fails.

### Why This Change is Necessary
Prevents unexpected crashes when the database connection fails or `CHAI_DATABASE_URL` is not set.
Provides clear, actionable feedback to the user.

### Changes
Added a validation step for `CHAI_DATABASE_URL`.
Added error handling for `psycopg2.OperationalError` during database connection.