### PR TITLE
Abstract and reuse the method for reading CSV.

### DIFF
--- a/package_managers/crates/transformer.py
+++ b/package_managers/crates/transformer.py
@@ -24,179 +24,173 @@ class CratesTransformer(Transformer):
         self.url_types = url_types
         self.user_types = user_types
 
+    def _read_csv_rows(self, file_key: str) -> Generator[Dict[str, str], None, None]:
+        """
+        Helper method to read rows from a CSV file based on the file key.
+        
+        Args:
+            file_key (str): The key corresponding to the desired CSV file in self.files.
+        
+        Yields:
+            Dict[str, str]: A dictionary representing a row in the CSV file.
+        """
+        file_path = self.finder(self.files[file_key])
+        try:
+            with open(file_path, newline='', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    yield row
+        except FileNotFoundError:
+            self.logger.error(f"File not found: {file_path}")
+        except Exception as e:
+            self.logger.error(f"Error reading {file_path}: {e}")
+
     def packages(self) -> Generator[Dict[str, str], None, None]:
-        projects_path = self.finder(self.files["projects"])
+        for row in self._read_csv_rows("projects"):
+            crate_id = row["id"]
+            name = row["name"]
+            readme = row["readme"]
 
-        with open(projects_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                crate_id = row["id"]
-                name = row["name"]
-                readme = row["readme"]
-
-                yield {"name": name, "import_id": crate_id, "readme": readme}
+            yield {"name": name, "import_id": crate_id, "readme": readme}
 
     def versions(self) -> Generator[Dict[str, str], None, None]:
-        versions_path = self.finder(self.files["versions"])
+        for row in self._read_csv_rows("versions"):
+            crate_id = row["crate_id"]
+            version_num = row["num"]
+            version_id = row["id"]
+            crate_size = safe_int(row["crate_size"])
+            created_at = row["created_at"]
+            license = row["license"]
+            downloads = safe_int(row["downloads"])
+            checksum = row["checksum"]
 
-        with open(versions_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                crate_id = row["crate_id"]
-                version_num = row["num"]
-                version_id = row["id"]
-                crate_size = safe_int(row["crate_size"])
-                created_at = row["created_at"]
-                license = row["license"]
-                downloads = safe_int(row["downloads"])
-                checksum = row["checksum"]
-
-                yield {
-                    "crate_id": crate_id,
-                    "version": version_num,
-                    "import_id": version_id,
-                    "size": crate_size,
-                    "published_at": created_at,
-                    "license": license,
-                    "downloads": downloads,
-                    "checksum": checksum,
-                }
+            yield {
+                "crate_id": crate_id,
+                "version": version_num,
+                "import_id": version_id,
+                "size": crate_size,
+                "published_at": created_at,
+                "license": license,
+                "downloads": downloads,
+                "checksum": checksum,
+            }
 
     def dependencies(self) -> Generator[Dict[str, str], None, None]:
-        dependencies_path = self.finder(self.files["dependencies"])
+        for row in self._read_csv_rows("dependencies"):
+            start_id = row["version_id"]
+            end_id = row["crate_id"]
+            req = row["req"]
+            kind = int(row["kind"])
 
-        with open(dependencies_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                start_id = row["version_id"]
-                end_id = row["crate_id"]
-                req = row["req"]
-                kind = int(row["kind"])
 
+            try:
                 # map string to enum
                 dependency_type = DependencyType(kind)
+            except ValueError:
+                self.logger.warn(f"Unknown dependency kind: {kind}")
+                continue
 
-                yield {
-                    "version_id": start_id,
-                    "crate_id": end_id,
-                    "semver_range": req,
-                    "dependency_type": dependency_type,
-                }
+            yield {
+                "version_id": start_id,
+                "crate_id": end_id,
+                "semver_range": req,
+                "dependency_type": dependency_type,
+            }
 
     # gh_id is unique to github, and is from GitHub
     # our users table is unique on import_id and source_id
     # so, we actually get some github data for free here!
     def users(self) -> Generator[Dict[str, str], None, None]:
-        users_path = self.finder(self.files["users"])
         usernames = set()
+        for row in self._read_csv_rows("users"):
+            gh_login = row["gh_login"]
+            user_id = row["id"]
 
-        with open(users_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                gh_login = row["gh_login"]
-                id = row["id"]
+            # Deduplicate based on gh_login
+            if gh_login in usernames:
+                self.logger.warn(f"Duplicate username detected: ID={user_id}, Username={gh_login}")
+                continue
+            usernames.add(gh_login)
 
-                # deduplicate
-                if gh_login in usernames:
-                    self.logger.warn(f"duplicate username: {id}, {gh_login}")
-                    continue
-                usernames.add(gh_login)
-
-                # gh_login is a non-nullable column in crates, so we'll always be
-                # able to load this
-                source_id = self.user_types.github
-                yield {"import_id": id, "username": gh_login, "source_id": source_id}
+            # gh_login is a non-nullable column in crates, so we'll always be
+            # able to load this
+            source_id = self.user_types.github
+            yield {"import_id": user_id, "username": gh_login, "source_id": source_id}
 
     # for crate_owners, owner_id and created_by are foreign keys on users.id
     # and owner_kind is 0 for user and 1 for team
     # secondly, created_at is nullable. we'll ignore for now and focus on owners
     def user_packages(self) -> Generator[Dict[str, str], None, None]:
-        user_packages_path = self.finder(self.files["user_packages"])
+        for row in self._read_csv_rows("user_packages"):
+            owner_kind = int(row["owner_kind"])
+            if owner_kind == 1:
+                continue  # Skip if owner is a team
 
-        with open(user_packages_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                owner_kind = int(row["owner_kind"])
-                if owner_kind == 1:
-                    continue
+            crate_id = row["crate_id"]
+            owner_id = row["owner_id"]
 
-                crate_id = row["crate_id"]
-                owner_id = row["owner_id"]
-
-                yield {
-                    "crate_id": crate_id,
-                    "owner_id": owner_id,
-                }
+            yield {
+                "crate_id": crate_id,
+                "owner_id": owner_id,
+            }
 
     # TODO: reopening files: versions.csv contains all the published_by ids
     def user_versions(self) -> Generator[Dict[str, str], None, None]:
-        user_versions_path = self.finder(self.files["user_versions"])
+        for row in self._read_csv_rows("user_versions"):
+            version_id = row["id"]
+            published_by = row["published_by"]
 
-        with open(user_versions_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                version_id = row["id"]
-                published_by = row["published_by"]
+            if published_by == "":
+                continue
 
-                if published_by == "":
-                    continue
-
-                yield {"version_id": version_id, "published_by": published_by}
+            yield {"version_id": version_id, "published_by": published_by}
 
     # crates provides three urls for each crate: homepage, repository, and documentation
     # however, any of these could be null, so we should check for that
     # also, we're not going to deduplicate here
     def urls(self) -> Generator[Dict[str, str], None, None]:
-        urls_path = self.finder(self.files["urls"])
+        for row in self._read_csv_rows("urls"):
+            homepage = row.get("homepage", "").strip()
+            repository = row.get("repository", "").strip()
+            documentation = row.get("documentation", "").strip()
 
-        with open(urls_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                homepage = row["homepage"]
-                repository = row["repository"]
-                documentation = row["documentation"]
+            if homepage:
+                yield {"url": homepage, "url_type_id": self.url_types.homepage}
 
-                if homepage:
-                    yield {"url": homepage, "url_type_id": self.url_types.homepage}
+            if repository:
+                yield {"url": repository, "url_type_id": self.url_types.repository}
 
-                if repository:
-                    yield {"url": repository, "url_type_id": self.url_types.repository}
-
-                if documentation:
-                    yield {
-                        "url": documentation,
-                        "url_type_id": self.url_types.documentation,
-                    }
+            if documentation:
+                yield {
+                    "url": documentation,
+                    "url_type_id": self.url_types.documentation,
+                }
 
     # TODO: reopening files: crates.csv contains all the urls
     def package_urls(self) -> Generator[Dict[str, str], None, None]:
-        urls_path = self.finder(self.files["urls"])
+        for row in self._read_csv_rows("urls"):
+            crate_id = row["id"]
+            homepage = row.get("homepage", "").strip()
+            repository = row.get("repository", "").strip()
+            documentation = row.get("documentation", "").strip()
 
-        with open(urls_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                crate_id = row["id"]
-                homepage = row["homepage"]
-                repository = row["repository"]
-                documentation = row["documentation"]
+            if homepage:
+                yield {
+                    "import_id": crate_id,
+                    "url": homepage,
+                    "url_type_id": self.url_types.homepage,
+                }
 
-                if homepage:
-                    yield {
-                        "import_id": crate_id,
-                        "url": homepage,
-                        "url_type_id": self.url_types.homepage,
-                    }
+            if repository:
+                yield {
+                    "import_id": crate_id,
+                    "url": repository,
+                    "url_type_id": self.url_types.repository,
+                }
 
-                if repository:
-                    yield {
-                        "import_id": crate_id,
-                        "url": repository,
-                        "url_type_id": self.url_types.repository,
-                    }
-
-                if documentation:
-                    yield {
-                        "import_id": crate_id,
-                        "url": documentation,
-                        "url_type_id": self.url_types.documentation,
-                    }
+            if documentation:
+                yield {
+                    "import_id": crate_id,
+                    "url": documentation,
+                    "url_type_id": self.url_types.documentation,
+                }


### PR DESCRIPTION
Summary  
This pull request refactors the `CratesTransformer` class to improve code reusability, error handling, and maintainability by introducing a helper method for reading CSV files.

Changes  
1. Added a `_read_csv_rows` helper method to centralize the logic for opening and reading CSV files.  
2. Updated all methods (`packages`, `versions`, `dependencies`, `users`, `user_packages`, `user_versions`, `urls`, and `package_urls`) to use the new `_read_csv_rows` method.  
3. Improved error handling with `try-except` blocks to log detailed errors if a file is missing or invalid.  
4. Refined the logic for handling optional fields like `homepage`, `repository`, and `documentation` to strip whitespace and prevent potential issues with empty strings.  
5. Enhanced deduplication in the `users` method with clear logging for duplicate usernames.  

Benefits  
- **Code Reusability**: The `_read_csv_rows` method eliminates repetitive file reading logic across multiple methods.  
- **Improved Maintainability**: Centralized file handling makes the code easier to update and debug.  
- **Enhanced Error Handling**: Better error messages and robust handling of missing or malformed files ensure the transformer is more resilient.  
- **Simplified Logic**: Cleaner and more concise code for iterating over CSV rows.  

