### PR TITLE
Fix alembic container by explicitly use /bin/sh to execute migration script

### DIFF
--- a/alembic/Dockerfile
+++ b/alembic/Dockerfile
@@ -8,4 +8,4 @@ RUN apt -y install python3-sqlalchemy python3-sqlalchemy-ext
 COPY . .
 WORKDIR /alembic
 RUN chmod +x /alembic/run_migrations.sh
-ENTRYPOINT ["/alembic/run_migrations.sh"]
+ENTRYPOINT ["/bin/sh", "/alembic/run_migrations.sh"]


### PR DESCRIPTION
## Description
Fixes an issue where the alembic container would fail to start on Docker Desktop for Windows due to script execution problems

## Changes
- Updated `alembic/Dockerfile` to explicitly use `/bin/sh` when executing the migration script

Fixes #40 