### PR TITLE
Fix syntax error and type mismatch

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -33,9 +33,9 @@ class ExecConf:
     no_cache: bool
 
     def __init__(self) -> None:
-        self.test = TEST.lower() == "true"
-        self.fetch = FETCH.lower() == "true"
-        self.no_cache = NO_CACHE.lower() == "true"
+        self.test = TEST
+        self.fetch = FETCH
+        self.no_cache = NO_CACHE
 
     def __str__(self):
         return f"ExecConf(test={self.test},fetch={self.fetch},no_cache={self.no_cache})"

--- a/core/config.py
+++ b/core/config.py
@@ -33,12 +33,12 @@ class ExecConf:
     no_cache: bool
 
     def __init__(self) -> None:
-        self.test = TEST
-        self.fetch = FETCH
-        self.no_cache = NO_CACHE
+        self.test = TEST.lower() == "true"
+        self.fetch = FETCH.lower() == "true"
+        self.no_cache = NO_CACHE.lower() == "true"
 
     def __str__(self):
-        return f"ExecConf(test={self.test},fetch={self.fetch},no_cache={self.no_cache}"
+        return f"ExecConf(test={self.test},fetch={self.fetch},no_cache={self.no_cache})"
 
 
 class PMConf:


### PR DESCRIPTION
***Description***

1. Syntax Error  - A closing curly brace` } `is missing in the f-string on line 41. This results in a syntax error because Python expects the expression inside the curly braces to be completed and the quotation marks to be closed.

2. Type Mismatch - The variables `TEST,` `FETCH`, and `NO_CACHE `are initialized using the `env_vars` function, which returns string values (e.g., `"true"` or `"false"`). However, in the `ExecConf` class, these variables are annotated as `bool`. Assigning string values to boolean attributes leads to a type mismatch.

If the string values are converted to booleans before assignment, this ensures that the `test`, `fetch`, and `no_cache` attributes will have the `bool` type, consistent with their annotations.






