### PR TITLE
docs: Fix capitalization of "API" in Docker Services Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ These arguments are all configurable in the `docker-compose.yml` file.
 1. `db`: [PostgreSQL] database for the reduced package data
 2. `alembic`: handles migrations
 3. `package_managers`: fetches and writes data for each package manager
-4. `api`: a simple REST api for reading from the db
+4. `api`: a simple REST API for reading from the db
 
 ### Hard Reset
 


### PR DESCRIPTION
I’ve corrected the capitalization of "API" in the Docker Services Overview.
The term "**API**" is typically written in all caps, so I’ve updated it to match that standard for consistency and clarity.