### PR TITLE
Use is_some_and instead of map_or(false) for database error checks

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.78.0 as chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.81.0 as chef
 WORKDIR /app
 
 FROM chef as planner

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -156,14 +156,14 @@ pub async fn get_table_row(
             }
             Err(e) => {
                 if e.as_db_error()
-                    .map_or(false, |e| e.code() == &SqlState::UNDEFINED_TABLE)
+                    .is_some_and(|db_err| db_err.code() == &SqlState::UNDEFINED_TABLE)
                 {
                     HttpResponse::NotFound().json(json!({
                         "error": format!("Table '{}' not found", table_name)
                     }))
                 } else if e
                     .as_db_error()
-                    .map_or(false, |e| e.code() == &SqlState::NO_DATA_FOUND)
+                    .is_some_and(|e| e.code() == &SqlState::NO_DATA_FOUND)
                 {
                     HttpResponse::NotFound().json(json!({
                         "error": format!("No row found with id '{}' in table '{}'", id, table_name)


### PR DESCRIPTION
**Description**
- Replaced `map_or(false, |e| ...)` with `.is_some_and(...)` for checking database errors.
- Simplifies the logic and aligns with Clippy’s suggestions.

**Why**
- This makes the code more readable and concise.
- Resolves the Clippy warning about `unnecessary_map_or`.
