### PR TITLE
fix: incorrect tolerance check using `abs` with Decimal

### DIFF
--- a/tests/unit/test_rx_graph.py
+++ b/tests/unit/test_rx_graph.py
@@ -36,9 +36,8 @@ def large_chai_graph() -> tuple[CHAI, dict[uuid.UUID, Decimal]]:
         uid: weight / total_weight
         for uid, weight in initial_personalization_raw.items()
     }
-    assert sum(personalization.values()) == pytest.approx(
-        Decimal(1.0)
-    ), "Initial personalization should sum to 1"
+    assert abs(sum(personalization.values()) - Decimal(1.0)) <= TOLERANCE, \
+        "Initial personalization should sum to 1 within tolerance"
 
     # Add random edges (potential cycles)
     node_indices = list(G.node_indices())


### PR DESCRIPTION
fixed a bug where tolerance was being checked inconsistently.

now the absolute deviation is correctly computed using `abs(...)`, and the comparison stays fully within the Decimal system. 

this ensures precise behavior when dealing with small tolerances, which is especially important for accuracy-sensitive calculations.