### PR TITLE
migration script for existing data to a package package dependency model

### DIFF
--- a/scripts/package_to_package/package_dependencies.py
+++ b/scripts/package_to_package/package_dependencies.py
@@ -1,0 +1,355 @@
+#! /usr/bin/env pkgx +python@3.11 uv run
+import argparse
+import re
+import sys
+from typing import Any, Dict, List, Optional
+
+from packaging import version as packaging_version
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from core.config import Config, PackageManager
+from core.db import DB
+from core.logger import Logger
+from core.models import DependsOn, LegacyDependency, Package, Version
+
+# --- Constants ---
+INSERT_BATCH_SIZE = 5000
+DEFAULT_SEMVER_RANGE = "*"
+
+logger = Logger("package_dependency_migration")
+
+# --- Helper Functions ---
+
+
+def preprocess_version_string(version_str: str) -> str:
+    """
+    Transforms known non-PEP440 version strings into a parseable format.
+    Handles specific date formats, build tags, and common non-standard separators.
+    """
+    # === General Cleanup / Normalization ===
+    # Replace underscores between digits or letters/digits
+    # Digit_Digit -> Digit.Digit
+    version_str = re.sub(r"(?<=\d)_(?=\d)", ".", version_str)
+
+    # Letter_Digit -> Letter.Digit
+    version_str = re.sub(r"(?<=[a-zA-Z])_(?=\d)", ".", version_str)
+
+    # Digit_Letter -> Digit.Letter
+    version_str = re.sub(r"(?<=\d)_(?=[a-zA-Z])", ".", version_str)
+
+    # === Pattern Matching & Transformation (Order Matters!) ===
+
+    # --- Specific Patterns First ---
+    # Handle X.Y.Z-M<number> -> X.Y.Z+M<number> (Milestone)
+    match_milestone = re.fullmatch(r"(\d+(\.\d+)*)-M(\d+)", version_str)
+    if match_milestone:
+        return f"{match_milestone.group(1)}+M{match_milestone.group(3)}"
+
+    # Handle X.Y.Z-<string>.<number> -> X.Y.Z+<string>.<number> (Vendor Build)
+    match_vendor_build = re.fullmatch(r"(\d+(\.\d+)+)-([a-zA-Z]+)\.(\d+)", version_str)
+    if match_vendor_build:
+        return f"{match_vendor_build.group(1)}+{match_vendor_build.group(3)}.{match_vendor_build.group(4)}"  # noqa
+
+    # Handle X.Y.Z-git<build> -> X.Y.Z+git<build>
+    match_git_build = re.fullmatch(r"(\d+(\.\d+)+)-(git[\da-zA-Z]+)", version_str)
+    if match_git_build:
+        return f"{match_git_build.group(1)}+{match_git_build.group(2)}"
+
+    # Handle X.Y.Z-p<number> / X.Y.Zp<number> -> X.Y.Z+p<number>
+    match_p_patch1 = re.fullmatch(r"(\d+(\.\d+)+)-p(\d+)", version_str)
+    if match_p_patch1:
+        return f"{match_p_patch1.group(1)}+p{match_p_patch1.group(3)}"
+    match_p_patch2 = re.fullmatch(r"(\d+(\.\d+)+)p(\d+)", version_str)
+    if match_p_patch2:
+        return f"{match_p_patch2.group(1)}+p{match_p_patch2.group(3)}"
+
+    # --- Date Formats ---
+    # YYYY-MM-DD -> YYYY.MM.DD
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", version_str):
+        return version_str.replace("-", ".")
+
+    # YYYYMMDDTHHMMSS -> YYYYMMDD.HHMMSS
+    match_ymdt_compact = re.fullmatch(r"(\d{8})T(\d{6})", version_str)
+    if match_ymdt_compact:
+        return f"{match_ymdt_compact.group(1)}.{match_ymdt_compact.group(2)}"
+
+    # YYYY.MM.DD-HH.MM.SS -> YYYY.MM.DD+HHMMSS
+    match_ymd_time_hyphen = re.fullmatch(
+        r"(\d{4}\.\d{2}\.\d{2})-(\d{2}\.\d{2}\.\d{2})", version_str
+    )
+    if match_ymd_time_hyphen:
+        time_part = match_ymd_time_hyphen.group(2).replace(".", "")
+        return f"{match_ymd_time_hyphen.group(1)}+{time_part}"
+
+    # ISO 8601 subset: YYYY-MM-DDTHH-MM-SSZ -> YYYY.MM.DD+HHMMSSZ
+    match_iso_subset = re.fullmatch(
+        r"(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})Z", version_str
+    )
+    if match_iso_subset:
+        date_part = f"{match_iso_subset.group(1)}.{match_iso_subset.group(2)}.{match_iso_subset.group(3)}"  # noqa
+        time_part = f"{match_iso_subset.group(4)}{match_iso_subset.group(5)}{match_iso_subset.group(6)}Z"  # noqa
+        return f"{date_part}+{time_part}"
+
+    # <datestamp>-<string|version> -> <datestamp>+<string|version>
+    match_date_suffix = re.fullmatch(r"(\d{8})-?(.*)", version_str)
+    if match_date_suffix and match_date_suffix.group(2):  # Ensure there is a suffix
+        # Check if suffix looks like a simple version number itself,
+        # otherwise treat as string
+        suffix = match_date_suffix.group(2)
+        # Normalize suffix by removing dots if it looks like a version part
+        # This helps comparison e.g., update1 vs 3.1 -> update1 vs 31
+        normalized_suffix = suffix.replace(".", "")
+        return f"{match_date_suffix.group(1)}+{normalized_suffix}"
+
+    # --- More General Build/Patch Identifiers ---
+    # Handle X.Y.Z.v<build> -> X.Y.Z+v<build>
+    match_v_build = re.fullmatch(r"(\d+(\.\d+)+)\.v(.*)", version_str)
+    if match_v_build:
+        return f"{match_v_build.group(1)}+v{match_v_build.group(3)}"
+
+    # Handle X.Yrel.<number> -> X.Y+rel.<number>
+    match_rel_build = re.fullmatch(r"(\d+(\.\d+)+)rel\.(.*)", version_str)
+    if match_rel_build:
+        return f"{match_rel_build.group(1)}+rel.{match_rel_build.group(3)}"
+
+    # Handle X.Yga<number> -> X.Y+ga<number>
+    match_ga_build = re.fullmatch(r"(\d+(\.\d+)+)ga(\d+)", version_str)
+    if match_ga_build:
+        return f"{match_ga_build.group(1)}+ga{match_ga_build.group(3)}"
+
+    # Handle <major>-<build> (comes after more specific hyphenated patterns)
+    match_major_build = re.fullmatch(r"(\d+)-([\da-zA-Z]+)", version_str)
+    if match_major_build:
+        return f"{match_major_build.group(1)}+{match_major_build.group(2)}"
+
+    # Handle X.Yp<number> -> X.Y+p<number>
+    match_p_patch3 = re.fullmatch(r"(\d+\.\d+)p(\d+)", version_str)
+    if match_p_patch3:
+        return f"{match_p_patch3.group(1)}+p{match_p_patch3.group(2)}"
+
+    # Handle r<number> -> 0+r<number>
+    match_revision = re.fullmatch(r"r(\d+)", version_str)
+    if match_revision:
+        return f"0+r{match_revision.group(1)}"
+
+    # Handle X.Y<single_letter_suffix> / X.Y<two_letter_suffix> -> X.Y+suffix
+    match_letter_suffix = re.fullmatch(r"(\d+\.\d+)([a-zA-Z]{1,2})", version_str)
+    if match_letter_suffix:
+        return f"{match_letter_suffix.group(1)}+{match_letter_suffix.group(2)}"
+
+    # Handle leading 'p' if it looks like p<version>
+    if version_str.startswith("p") and re.match(r"p\d", version_str):
+        potential_version = version_str[1:]
+        try:
+            packaging_version.parse(potential_version)
+            return potential_version
+        except packaging_version.InvalidVersion:
+            pass
+
+    # --- Fallback ---
+    return version_str
+
+
+def get_latest_version_info(versions: List[Version]) -> Optional[Version]:
+    """
+    Identifies the latest version from a list using packaging.version for robust parsing
+    unless there is only one version provided.
+
+    Args:
+        versions: A list of Version objects for a single package.
+
+    Returns:
+        The single Version object if only one is provided.
+        Otherwise, the Version object corresponding to the latest parseable version.
+        Returns None if the list is empty or no versions could be parsed (when >1 version).
+    """
+    # Handle empty list
+    if not versions:
+        return None
+
+    # If there's only one version, return it directly without parsing
+    if len(versions) == 1:
+        return versions[0]
+
+    # Proceed with parsing and comparison if more than one version exists
+    latest_parsed_version = None
+    latest_version_obj = None
+
+    for version_obj in versions:
+        original_version_str = version_obj.version
+        preprocessed_str = preprocess_version_string(original_version_str)
+        try:
+            current_parsed_version = packaging_version.parse(preprocessed_str)
+            if (
+                latest_parsed_version is None
+                or current_parsed_version > latest_parsed_version
+            ):
+                latest_parsed_version = current_parsed_version
+                latest_version_obj = version_obj
+        except packaging_version.InvalidVersion as e_invalid:
+            logger.warn(
+                f"'{original_version_str}' -> '{preprocessed_str}') -> {e_invalid}"
+            )
+            continue
+        except Exception as e_general:
+            logger.error(
+                f"Unexpected error: '{original_version_str}' -> '{preprocessed_str}' -> {e_general}"  # noqa
+            )
+            continue
+
+    # If no versions were successfully processed
+    if latest_version_obj is None:
+        import_id = versions[0].import_id
+        versions_str = ", ".join([v.version for v in versions])
+        logger.warn(f"No versions for {import_id}: {versions_str}")
+
+    return latest_version_obj
+
+
+def insert_legacy_dependencies(
+    session: Session, data_batch: List[Dict[str, Any]]
+) -> None:
+    """
+    Inserts a batch of legacy dependency records into the database,
+    ignoring duplicates based on the (package_id, dependency_id) unique constraint.
+
+    Args:
+        session: The SQLAlchemy session object.
+        data_batch: A list of dictionaries, each representing a LegacyDependency row.
+    """
+    if not data_batch:
+        return
+
+    try:
+        # Get the target table object
+        legacy_table = LegacyDependency.__table__
+
+        # Construct the PostgreSQL INSERT...ON CONFLICT DO NOTHING statement
+        stmt = pg_insert(legacy_table).values(data_batch)
+        # Specify the columns involved in the unique constraint
+        # The constraint name 'uq_package_dependency' is defined in the model
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=["package_id", "dependency_id"]
+        )
+
+        # Execute the statement
+        session.execute(stmt)
+        session.commit()
+
+    except IntegrityError as e:
+        logger.error(f"Database Integrity Error during insert: {e}")
+        session.rollback()
+        raise e
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during bulk insert: {e}")
+        session.rollback()
+        raise e
+
+
+# --- Main Processing Function ---
+
+
+def process_package_dependencies(config: Config, session: Session) -> None:
+    legacy_deps_to_insert: List[Dict[str, Any]] = []
+    total_packages_processed = 0
+    total_dependencies_found = 0
+    default_dependency_type_id = config.dependency_types.runtime
+
+    logger.log(f"Starting migration for package manager ID: {config.pm_config.pm_id}")
+
+    # --- Fetch ALL packages for the manager ---
+    logger.log("Fetching all packages for the specified manager...")
+    all_packages: List[Package] = (
+        session.query(Package)
+        .filter(Package.package_manager_id == config.pm_config.pm_id)
+        .all()  # Fetch all into memory
+    )
+    logger.log(f"Fetched {len(all_packages)} packages.")
+
+    # --- Process all fetched packages ---
+    for pkg in all_packages:
+        total_packages_processed += 1
+        if total_packages_processed % 1000 == 0:
+            logger.debug(
+                f"Processed {total_packages_processed}/{len(all_packages)} packages..."
+            )
+
+        versions = session.query(Version).filter(Version.package_id == pkg.id).all()
+        if not versions:
+            continue
+        latest_version = get_latest_version_info(versions)
+        if latest_version is None:
+            continue
+
+        dependencies = (
+            session.query(DependsOn)
+            .filter(DependsOn.version_id == latest_version.id)
+            .all()
+        )
+
+        for dependency in dependencies:
+            dep_data = {
+                "package_id": pkg.id,
+                "dependency_id": dependency.dependency_id,
+                "dependency_type_id": dependency.dependency_type_id
+                or default_dependency_type_id,
+                "semver_range": dependency.semver_range or DEFAULT_SEMVER_RANGE,
+            }
+            legacy_deps_to_insert.append(dep_data)
+            total_dependencies_found += 1
+
+        # --- Check insert batch size ---
+        if len(legacy_deps_to_insert) >= INSERT_BATCH_SIZE:
+            logger.log(f"Reached insert batch size ({INSERT_BATCH_SIZE}). Inserting...")
+            insert_legacy_dependencies(session, legacy_deps_to_insert)
+            legacy_deps_to_insert = []  # Clear the batch
+
+    # --- Final Insert ---
+    if legacy_deps_to_insert:
+        logger.log(
+            f"Inserting final batch of {len(legacy_deps_to_insert)} dependency records."
+        )
+        insert_legacy_dependencies(session, legacy_deps_to_insert)
+
+    logger.log("--- Migration Summary ---")
+    logger.log(f"Total packages processed: {total_packages_processed}")
+    logger.log(f"Total dependencies found: {total_dependencies_found}")
+    logger.log("Migration process completed.")
+
+
+# --- Main Execution ---
+
+if __name__ == "__main__":
+    desc = """Migrate version-specific dependencies to package-level dependencies based 
+    on the latest version."""
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument(
+        "--package-manager",
+        type=lambda pm: PackageManager[pm.upper()],
+        choices=list(PackageManager),
+        required=True,
+        help="The package manager to process (e.g., NPM, CRATES).",
+    )
+
+    args = parser.parse_args()
+
+    logger.log(
+        f"Starting package dependency migration for: {args.package_manager.name}"
+    )
+
+    SessionLocal = None
+    try:
+        config = Config(args.package_manager)
+        db = DB("db_logger")
+        SessionLocal = sessionmaker(bind=db.engine)
+
+        with SessionLocal() as session:
+            process_package_dependencies(config, session)
+
+    except Exception as e:
+        logger.error(f"An critical error occurred: {e}")
+        sys.exit(1)
+    finally:
+        logger.log("Script finished.")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ testing.postgresql==1.3.0
 sqlalchemy==2.0.28
 psycopg2-binary==2.9.9
 pytest-cov==4.1.0 
+semver==3.0.4

--- a/tests/scripts/package_to_package/test_package_dependencies.py
+++ b/tests/scripts/package_to_package/test_package_dependencies.py
@@ -131,11 +131,3 @@ def test_get_latest_version_info(version_list_strs, expected_latest_str):
             latest_version_obj is not None
         ), f"No latest version found for {version_list_strs}"  # noqa
         assert latest_version_obj.version == expected_latest_str
-
-
-# Example of a test specifically for a version structure if needed later
-# def test_get_latest_version_info_specific():
-#     versions = [create_mock_version("1.0.0-alpha"), create_mock_version("1.0.0")]
-#     latest = get_latest_version_info(versions)
-#     assert latest is not None
-#     assert latest.version == "1.0.0"

--- a/tests/scripts/package_to_package/test_package_dependencies.py
+++ b/tests/scripts/package_to_package/test_package_dependencies.py
@@ -16,7 +16,7 @@ def create_mock_version(version_str: str) -> Mock:
     [
         # === Basic Cases ===
         ([], None),
-        (["gibberish"], "gibberish"),
+        (["gibberish"], "gibberish"),  # because only one entry
         (["1.0.0", "1.1.0", "1.0.1"], "1.1.0"),
         (["1.1.0", "1.0.0", "0.9.0"], "1.1.0"),
         (["1.0", "1.0.1"], "1.0.1"),
@@ -41,7 +41,6 @@ def create_mock_version(version_str: str) -> Mock:
         (["4.0.0", "4.07", "3.9.9"], "4.07"),
         (["5.9.0", "5.09.03", "5.8.9"], "5.09.03"),
         (["0.58", "0.58b"], "0.58b"),
-        (["4.5.3", "4.5.3b", "4.5.2"], "4.5.3"),
         (["1.4rc5", "1.0.0", "2025.01.13", "1.1.0", "2.4h"], "2025.01.13"),
         (["2.6.4.3", "5.2.10.0", "0.11.0.0", "1.0b3", "11-062"], "11-062"),
         # YYYY-MM-DD
@@ -63,8 +62,6 @@ def create_mock_version(version_str: str) -> Mock:
         ),  # Preprocessed to YYYY.MM.DD+HHMMSS
         # Base version > with local identifier
         (["2025.03.27-20.21.36"], "2025.03.27-20.21.36"),  # Single version bypass
-        # Milestone -M<num>
-        (["3.0.2"], "3.0.0-M2"),  # Single version bypass
         # === New Preprocessing Test Cases ===
         (["4.7w", "4.7x"], "4.7x"),
         (["4.7w", "4.7"], "4.7w"),
@@ -111,6 +108,7 @@ def create_mock_version(version_str: str) -> Mock:
             ],
             "0.3.0-nightly.4",
         ),
+        (["1.1.1s", "1.1.1t", "1.1.1u"], "1.1.1u"),
     ],
 )
 def test_get_latest_version_info(version_list_strs, expected_latest_str):

--- a/tests/scripts/package_to_package/test_package_dependencies.py
+++ b/tests/scripts/package_to_package/test_package_dependencies.py
@@ -1,0 +1,141 @@
+from unittest.mock import Mock
+
+import pytest
+
+from scripts.package_to_package.package_dependencies import get_latest_version_info
+
+
+def create_mock_version(version_str: str) -> Mock:
+    mock = Mock()
+    mock.version = version_str
+    return mock
+
+
+@pytest.mark.parametrize(
+    "version_list_strs, expected_latest_str",
+    [
+        # === Basic Cases ===
+        ([], None),
+        (["gibberish"], "gibberish"),
+        (["1.0.0", "1.1.0", "1.0.1"], "1.1.0"),
+        (["1.1.0", "1.0.0", "0.9.0"], "1.1.0"),
+        (["1.0", "1.0.1"], "1.0.1"),
+        (["1.2", "1.1.0"], "1.2"),
+        (["2", "1.9.9"], "2"),
+        (["1.4rc5", "1.3"], "1.4rc5"),
+        (["004", "3"], "004"),
+        (["11-062", "10.0"], "11-062"),
+        (["1.0b3", "1.0b2"], "1.0b3"),
+        (["1.0.0", "1.4rc5", "1.1.0"], "1.4rc5"),
+        (["1.9.0", "2.6.4.3", "1.10.0", "5.2.10.0"], "5.2.10.0"),
+        (["0.10.0", "0.11.0.0", "0.9.0"], "0.11.0.0"),
+        (["3.0.0", "3.01", "2.9.9"], "3.01"),
+        (["1.0.8", "1.09", "1.0.0"], "1.09"),
+        (["1.3.0", "1.3.0rc1", "1.2.9"], "1.3.0"),
+        (["0.1.0", "019", "0.0.1"], "019"),
+        (["1.0.0", "1.07.1", "0.9.9"], "1.07.1"),
+        (["3.0.0", "3.07", "2.9.9"], "3.07"),
+        (["4.6a", "4.5b"], "4.6a"),
+        (["25.0.0", "25.03", "24.9.9"], "25.03"),
+        (["0.9.0", "0.H", "0.8.0"], "0.9.0"),
+        (["4.0.0", "4.07", "3.9.9"], "4.07"),
+        (["5.9.0", "5.09.03", "5.8.9"], "5.09.03"),
+        (["0.58", "0.58b"], "0.58b"),
+        (["4.5.3", "4.5.3b", "4.5.2"], "4.5.3"),
+        (["1.4rc5", "1.0.0", "2025.01.13", "1.1.0", "2.4h"], "2025.01.13"),
+        (["2.6.4.3", "5.2.10.0", "0.11.0.0", "1.0b3", "11-062"], "11-062"),
+        # YYYY-MM-DD
+        (["2025.01.13", "2024.12.31"], "2025.01.13"),
+        (["2024-11-26", "2024-12-31", "2025-02-25"], "2025-02-25"),
+        (["2024.11.25", "2024-11-26"], "2024-11-26"),  # Mix with standard
+        (["2024-11-26"], "2024-11-26"),  # Single version bypass
+        # YYYYMMDDTHHMMSS
+        (
+            ["20241108T174929", "20241108.174928"],
+            "20241108T174929",
+        ),  # Preprocessed to YYYYMMDD.HHMMSS
+        (["20241109T000000", "20241108.235959"], "20241109T000000"),
+        (["20241108T174929"], "20241108T174929"),  # Single version bypass
+        # YYYY.MM.DD-HH.MM.SS
+        (
+            ["2025.03.27-20.21.36", "2025.03.27+202135"],
+            "2025.03.27-20.21.36",
+        ),  # Preprocessed to YYYY.MM.DD+HHMMSS
+        # Base version > with local identifier
+        (["2025.03.27-20.21.36"], "2025.03.27-20.21.36"),  # Single version bypass
+        # Milestone -M<num>
+        (["3.0.2"], "3.0.0-M2"),  # Single version bypass
+        # === New Preprocessing Test Cases ===
+        (["4.7w", "4.7x"], "4.7x"),
+        (["4.7w", "4.7"], "4.7w"),
+        (
+            ["0.16.2-gitlab.30", "0.16.2-gitlab.31", "0.16.2-gitlab.35"],
+            "0.16.2-gitlab.35",
+        ),
+        (["3.1.3-p1", "3.2.2"], "3.2.2"),
+        (["9.4.56.v20240826", "9.4.57.v20241219"], "9.4.57.v20241219"),
+        (["9.4.56", "9.4.56.v20240826"], "9.4.56.v20240826"),  # +local > base
+        (["20240829-update1", "20240829-update2"], "20240829-update2"),
+        (["20240829", "20240829-update1"], "20240829-update1"),
+        (["20240808-3.1", "20250104-3.1"], "20250104-3.1"),
+        (["20240808", "20240808-3.1"], "20240808-3.1"),
+        (["2.8.9rel.1", "2.8.9"], "2.8.9rel.1"),
+        (["2025-04-08T15-41-24Z", "2025-04-08T15-39-49Z"], "2025-04-08T15-41-24Z"),
+        (["16-747c6", "17-b804f"], "17-b804f"),
+        (["16", "16-747c6"], "16-747c6"),
+        (["9.9p1", "9.9p2"], "9.9p2"),
+        (["9.9", "9.9p1"], "9.9p1"),
+        (["2024_12_11.09478d5", "2025_03_20.32f6212"], "2025_03_20.32f6212"),
+        (["4.4.0p8", "4.4.0"], "4.4.0p8"),
+        (["p6.1.20241222.0", "p6.1.20250112.0"], "p6.1.20250112.0"),
+        (
+            ["6.1.20241222.0", "p6.1.20241222.0"],
+            "6.1.20241222.0",
+        ),  # Base > preprocessed p-stripped
+        (["r1951", "r1980"], "r1980"),
+        (["0.1", "r1951"], "0.1"),  # Version 0.1 > 0+r1951
+        (["9.8z", "9.8za"], "9.8za"),
+        (["9.8", "9.8z"], "9.8z"),
+        (["0.5.3-git20230121", "0.5.3"], "0.5.3"),
+        (["4.3ga10", "4.4ga5"], "4.4ga5"),
+        (["4.3", "4.3ga10"], "4.3ga10"),
+        (
+            [
+                "0.1.13",
+                "0.3.0",
+                "0.3.0-nightly.3",
+                "0.3.0-nightly.2",
+                "0.3.1-nightly",
+                "0.3.0-nightly",
+                "0.3.0-nightly.4",
+            ],
+            "0.3.0-nightly.4",
+        ),
+    ],
+)
+def test_get_latest_version_info(version_list_strs, expected_latest_str):
+    """
+    Tests the get_latest_version_info function with various version string formats.
+    """
+    # Create mock Version objects from the strings
+    mock_versions = [create_mock_version(v_str) for v_str in version_list_strs]
+
+    # Call the function under test
+    latest_version_obj = get_latest_version_info(mock_versions)
+
+    # Assert the result
+    if expected_latest_str is None:
+        assert latest_version_obj is None
+    else:
+        assert (
+            latest_version_obj is not None
+        ), f"No latest version found for {version_list_strs}"  # noqa
+        assert latest_version_obj.version == expected_latest_str
+
+
+# Example of a test specifically for a version structure if needed later
+# def test_get_latest_version_info_specific():
+#     versions = [create_mock_version("1.0.0-alpha"), create_mock_version("1.0.0")]
+#     latest = get_latest_version_info(versions)
+#     assert latest is not None
+#     assert latest.version == "1.0.0"


### PR DESCRIPTION
- works by invoking it directly `scripts/package_to_package/package_dependencies.py --package-manager homebrew`
- it grabs the latest version per package, and loads that into the `LegacyDependsOn` table
- plan to rename `LegacyDependsOn` to `DependsOn` once all the indexers are updated to load to that table

## TODOs:

- few more PRs will be incoming to load the Legacy Depends On table directly
- loading dependencies will now be a destructive operation too, since we're looking at the latest version's dependencies only --- if an older version depended on foo, and the latest one doesn't, we should remove the foo dependency.