### PR TITLE
ci: upgrade actions/checkout to v4 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       alembic: ${{ steps.filter.outputs.alembic }}
       any_changes: ${{ steps.filter.outputs.any_changes }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -71,7 +71,7 @@ jobs:
     environment: ${{ inputs.env || 'dev' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.env || 'dev' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3


### PR DESCRIPTION
- Replace `actions/checkout@v3` with `actions/checkout@v4` in `.github/workflows/deploy.yml`
- Brings Node 20 runtime, faster fetch-depth handling, and recent security fixes

[Ref](https://github.com/actions/checkout#checkout-v4)