### PR TITLE
add trgm indexes

### DIFF
--- a/alembic/versions/20250508_1752-add_trgm_indexes.py
+++ b/alembic/versions/20250508_1752-add_trgm_indexes.py
@@ -1,0 +1,53 @@
+"""add_trgm_indexes
+
+Revision ID: 7392d4d74ce2
+Revises: a41236bd2340
+Create Date: 2025-05-08 17:52:40.417822
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7392d4d74ce2"
+down_revision: Union[str, None] = "a41236bd2340"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Drop the existing indexes
+    op.drop_index("ix_canons_name", table_name="canons")
+    op.drop_index("ix_urls_url", table_name="urls")
+
+    # Create trigram indexes
+    # NOTE: this was added manually to this script (not auto-generated)
+    op.create_index(
+        "ix_urls_url_trgm",
+        "urls",
+        ["url"],
+        unique=False,
+        postgresql_using="gin",
+        postgresql_ops={"url": "gin_trgm_ops"},
+    )
+    op.create_index(
+        "ix_canons_name_trgm",
+        "canons",
+        ["name"],
+        unique=False,
+        postgresql_using="gin",
+        postgresql_ops={"name": "gin_trgm_ops"},
+    )
+
+
+def downgrade() -> None:
+    # Drop the trigram indexes
+    # NOTE: this was added manually to this script (not auto-generated)
+    op.drop_index("ix_urls_url_trgm", table_name="urls")
+    op.drop_index("ix_canons_name_trgm", table_name="canons")
+
+    # Recreate the existing indexes (auto-generated)
+    op.create_index("ix_urls_url", "urls", ["url"], unique=False)
+    op.create_index("ix_canons_name", "canons", ["name"], unique=False)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -5,6 +5,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     MetaData,
     String,
@@ -261,7 +262,13 @@ class URL(Base):
         default=func.uuid_generate_v4(),
         server_default=func.uuid_generate_v4(),
     )
-    url = Column(String, nullable=False, index=True)
+    url_trgm_idx = Index(
+        "ix_urls_url_trgm",
+        "url",
+        postgresql_using="gin",
+        postgresql_ops={"url": "gin_trgm_ops"},
+    )
+    url = Column(String, nullable=False)
     url_type_id = Column(
         UUID(as_uuid=True), ForeignKey("url_types.id"), nullable=False, index=True
     )
@@ -451,7 +458,13 @@ class Canon(Base):
     id = Column(UUID(as_uuid=True), primary_key=True)
     url = Column(String, nullable=False, index=True, unique=True)  # the derived key
     # CanonNames should be its own table, so we collect all aliases of a package!
-    name = Column(String, nullable=False, index=True)
+    name_trgm_idx = Index(
+        "ix_canons_name_trgm",
+        "name",
+        postgresql_using="gin",
+        postgresql_ops={"name": "gin_trgm_ops"},
+    )
+    name = Column(String, nullable=False)
     created_at = Column(
         DateTime, nullable=False, default=func.now(), server_default=func.now()
     )


### PR DESCRIPTION
adding trgm indexes on the fields that the tea app uses to search for CHAI projects, to improve efficiency of the search. note that this is a stopgap, and we should probs investigate:

- bigram extension
- dedicated search columns with their own indexes

for now, this does result in a pretty significant improvement in the query planner's cost estimation for running the search query using a wildcard on the canons and URLs table. 