### PR TITLE
Replace deprecated NPM “/-/all” endpoint with CouchDB feed

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -28,7 +28,7 @@ SOURCES = {
         "https://ftp.debian.org/debian/dists/stable/main/binary-amd64/Packages.gz",
         "https://ftp.debian.org/debian/dists/stable/main/source/Sources.gz",
     ],
-    PackageManager.NPM: "https://registry.npmjs.org/-/all",  # fake for now
+    PackageManager.NPM: "https://replicate.npmjs.com/registry/_all_docs",  # fake for now
     PackageManager.PKGX: "https://github.com/pkgxdev/pantry.git",
 }
 


### PR DESCRIPTION
Description: The “/-/all” endpoint was shut down in 2017:contentReference[oaicite:0]{index=0}, so it no longer returns package data.  
Switching to https://replicate.npmjs.com/registry/_all_docs gives a live CouchDB replication feed that  
• lists every public package (incl. scoped ones)  
• supports incremental updates via /_changes, saving bandwidth  
• is the officially maintained source used by npm’s own mirrors.  
This keeps the ingest pipeline reliable and future-proof.






