### PR TITLE
two-step migration for new canons

### DIFF
--- a/alembic/versions/20250529_2341-rename_canons_table_and_recreate.py
+++ b/alembic/versions/20250529_2341-rename_canons_table_and_recreate.py
@@ -1,0 +1,96 @@
+"""rename_canons_table_and_recreate
+
+Revision ID: 542d79f30fc9
+Revises: 7392d4d74ce2
+Create Date: 2025-05-29 23:41:38.465987
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "542d79f30fc9"
+down_revision: Union[str, None] = "7392d4d74ce2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Rename existing canons table and create new one with proper url_id FK
+    """
+    # Step 1: Rename existing table to preserve data as backup
+    op.rename_table("canons", "canons_old")
+
+    # Step 2: Drop FK constraints that pointed to old table
+    op.drop_constraint(
+        "fk_canon_packages_canon_id_canons", "canon_packages", type_="foreignkey"
+    )
+    op.drop_constraint("fk_tea_ranks_canon_id_canons", "tea_ranks", type_="foreignkey")
+
+    # Step 3: Create new canons table with proper schema
+    op.create_table(
+        "canons",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.func.uuid_generate_v4(),
+        ),
+        sa.Column(
+            "url_id", UUID(as_uuid=True), nullable=False, index=True, unique=True
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+        ),
+        # Constraints
+        sa.ForeignKeyConstraint(["url_id"], ["urls.id"], name="fk_canons_url_id_urls"),
+        sa.UniqueConstraint("url_id", name="uq_canons_url_id"),
+    )
+
+    # Step 4: Create indexes
+    op.create_index("ix_canons_url_id", "canons", ["url_id"])
+    op.create_index(
+        "ix_canons_name_trgm",
+        "canons",
+        ["name"],
+        postgresql_using="gin",
+        postgresql_ops={"name": "gin_trgm_ops"},
+    )
+
+    # Note: FK constraints to this table will be recreated in a separate migration
+    # after data population, since this table starts empty
+
+
+def downgrade() -> None:
+    """
+    Restore original canons table
+    """
+    # FK constraints were dropped in upgrade and not recreated, so no need to drop them here
+
+    # Drop new table
+    op.drop_table("canons")
+
+    # Restore old table
+    op.rename_table("canons_old", "canons")
+
+    # Recreate original FK constraints
+    op.create_foreign_key(
+        "fk_canon_packages_canon_id_canons",
+        "canon_packages",
+        "canons",
+        ["canon_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "fk_tea_ranks_canon_id_canons", "tea_ranks", "canons", ["canon_id"], ["id"]
+    )

--- a/alembic/versions/20250529_2345-recreate_canon_foreign_keys.py
+++ b/alembic/versions/20250529_2345-recreate_canon_foreign_keys.py
@@ -1,0 +1,56 @@
+"""recreate_canon_foreign_keys
+
+Revision ID: 3de32bb99a71
+Revises: 542d79f30fc9
+Create Date: 2025-05-29 23:45:12.372951
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3de32bb99a71"
+down_revision: Union[str, None] = "542d79f30fc9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Recreate FK constraints pointing to canons table after data population
+    Run this AFTER your canonicalization script has populated the canons table
+    """
+    # First, clean up any orphaned records in referencing tables
+    # (Optional: uncomment if you want to auto-clean orphaned data)
+    # op.execute("""
+    #     DELETE FROM canon_packages
+    #     WHERE canon_id NOT IN (SELECT id FROM canons)
+    # """)
+    # op.execute("""
+    #     DELETE FROM tea_ranks
+    #     WHERE canon_id NOT IN (SELECT id FROM canons)
+    # """)
+
+    # Recreate FK constraints
+    op.create_foreign_key(
+        "fk_canon_packages_canon_id_canons",
+        "canon_packages",
+        "canons",
+        ["canon_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "fk_tea_ranks_canon_id_canons", "tea_ranks", "canons", ["canon_id"], ["id"]
+    )
+
+
+def downgrade() -> None:
+    """
+    Drop FK constraints pointing to canons table
+    """
+    op.drop_constraint(
+        "fk_canon_packages_canon_id_canons", "canon_packages", type_="foreignkey"
+    )
+    op.drop_constraint("fk_tea_ranks_canon_id_canons", "tea_ranks", type_="foreignkey")

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -472,9 +472,19 @@ class LegacyDependency(Base):
 
 class Canon(Base):
     __tablename__ = "canons"
-    id = Column(UUID(as_uuid=True), primary_key=True)
-    url = Column(String, nullable=False, index=True, unique=True)  # the derived key
-    # CanonNames should be its own table, so we collect all aliases of a package!
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=func.uuid_generate_v4(),
+        server_default=func.uuid_generate_v4(),
+    )
+    url_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("urls.id"),
+        nullable=False,
+        index=True,
+        unique=True,
+    )
     name_trgm_idx = Index(
         "ix_canons_name_trgm",
         "name",
@@ -488,6 +498,8 @@ class Canon(Base):
     updated_at = Column(
         DateTime, nullable=False, default=func.now(), server_default=func.now()
     )
+
+    url: Mapped["URL"] = relationship()
 
 
 class CanonPackage(Base):


### PR DESCRIPTION
Another one related to #93.

Achieves the dependency from canons to URLs. This should've always been a canons to `url_id` table, so this adjusts the design flaw by making it consistent with the rest of our table structures. I've broken out the migration into two steps because:

1. Renames old table to canons_old, removes all foreign key constraints, and creates the new canons table so we're ready to load it using our deduplicator script
2. Re-establishes all the foreign keys

## Note

1. We'll need to run the dedupe.py script to load new canons 
2. We'll need to truncate canon_packages and old tea_ranks

2 won't be an issue because the way we're conceptualizing the graph is not changing, just the structure of the table. 