### PR TITLE
docs (README.md): change command to restart-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ psql "postgresql://postgres:s3cr3t@localhost:5435/chai" -c "SELECT * FROM load_h
 Refreshes table knowledge from the db.
 
 ```sh
-docker-compose restart api
+docker compose restart api
 ```
 
 ### remove-orphans


### PR DESCRIPTION

* **Old version:** `docker-compose` (with a hyphen) – this was the older command that required a separate installation of the `docker-compose` tool.

* **New version (recommended):** `docker compose`  – this is the modern, official Docker CLI syntax supported since Docker version 20.10.

So always use:

```sh
docker compose restart api
```

