### PR TITLE
Fix incorrect Docker Compose usage for single package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use [Docker](https://docker.com)
 > - pkgx
 >
 > You can run a single package manager by running
-> `docker compose up -e ... <package_manager>`
+> `PACKAGE_MANAGER=<name> docker compose up`
 >
 > We are planning on supporting `NPM`, `PyPI`, and `rubygems` next.
 


### PR DESCRIPTION
### PR Description

**Enable selective package manager runs via `PACKAGE_MANAGER=<name> docker compose up`**

This PR introduces a cleaner way to run **only one package manager** pipeline at a time by using an environment variable:

```sh
PACKAGE_MANAGER=<name> docker compose up
```

---

### Problem

Previously, docs or examples suggested:

```sh
docker compose up -e PACKAGE_MANAGER=<name>
```

This syntax is **invalid** in Docker Compose — `-e` is **not a valid flag** for `docker compose up`. This caused confusion and led to incorrect execution or failure to inject the environment variable properly.

---

### Solution

By exporting the variable *inline* before the command, Docker correctly injects `PACKAGE_MANAGER` into the container environment:

```sh
PACKAGE_MANAGER=crates docker compose up
```

This approach works **as long as** `PACKAGE_MANAGER` is referenced in the `docker-compose.yml` or consumed in application logic (e.g. to only run a specific indexer).

---

