### PR TITLE
fix(alembic)

### DIFF
--- a/alembic/Dockerfile
+++ b/alembic/Dockerfile
@@ -1,4 +1,3 @@
-# TODO: run_migrations.sh uses psql, so we need that
 FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 RUN apt update && apt -y install postgresql
 RUN uv pip install alembic==1.13.2 psycopg2-binary==2.9.10 sqlalchemy==2.0.41 --system

--- a/alembic/Dockerfile
+++ b/alembic/Dockerfile
@@ -1,5 +1,6 @@
 # TODO: run_migrations.sh uses psql, so we need that
 FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+RUN apt update && apt -y install postgresql
 RUN uv pip install alembic==1.13.2 psycopg2-binary==2.9.10 sqlalchemy==2.0.41 --system
 COPY . . 
 WORKDIR /alembic

--- a/alembic/run_migrations.sh
+++ b/alembic/run_migrations.sh
@@ -4,32 +4,13 @@ set -uo pipefail
 
 # This script sets up the database, runs migrations, and loads initial values
 
-# NOTE: we don't need to wait for the database to be ready explicitly because docker
-# compose already defines the dependency
-# Also, in infra, the database would already exist
-# until pg_isready -h "$CHAI_DATABASE_URL" -p 5432 -U postgres; do
-#   echo "waiting for database..."
-#   sleep 2
-# done
-
 # Check if the 'chai' database exists, create it if it doesn't
-# Parse CHAI_DATABASE_URL: postgresql://user:password@host:port/dbname
-# Extract components
-DB_USER=$(echo "$CHAI_DATABASE_URL" | sed -n 's|.*://\([^:]*\):.*|\1|p')
-DB_PASSWORD=$(echo "$CHAI_DATABASE_URL" | sed -n 's|.*://[^:]*:\([^@]*\)@.*|\1|p')
-DB_HOST=$(echo "$CHAI_DATABASE_URL" | sed -n 's|.*@\([^:]*\):.*|\1|p')
-DB_PORT=$(echo "$CHAI_DATABASE_URL" | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
-DB_NAME=$(echo "$CHAI_DATABASE_URL" | sed -n 's|.*/\([^/]*\)$|\1|p')
-
-export PGPASSWORD="$DB_PASSWORD"
-
-# Connect to 'postgres' database to check if 'chai' exists
-if psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='chai'" | grep -q 1
+if psql "$CHAI_DATABASE_ADMIN_URL" -tAc "SELECT 1 FROM pg_database WHERE datname='chai'" | grep -q 1
 then
     echo "Database 'chai' already exists"
 else
     echo "Database 'chai' does not exist, creating..."
-    psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d postgres -f init-script.sql -a
+    psql "$CHAI_DATABASE_ADMIN_URL" -f init-script.sql -a
 fi
 
 # Run migrations and load data (uses 'chai' database)
@@ -37,6 +18,6 @@ echo "Current database version: $(alembic current)"
 alembic upgrade head || { echo "Migration failed"; exit 1; }
 
 echo "Loading initial values into the database..."
-psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f load-values.sql -a
+psql "$CHAI_DATABASE_URL" -f load-values.sql -a
 
 echo "Database setup and initialization complete"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       dockerfile: ./alembic/Dockerfile
     environment:
       - CHAI_DATABASE_URL=${CHAI_DATABASE_URL:-postgresql://postgres:s3cr3t@db:5432/chai}
+      - CHAI_DATABASE_ADMIN_URL=${CHAI_DATABASE_URL:-postgresql://postgres:s3cr3t@db:5432/postgres}
       - PGPASSWORD=${CHAI_DB_PASSWORD:-s3cr3t}
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "5435:5432"
     volumes:
-      - ./data/db/data:/var/lib/postgresql/data
+      - ./data/db/data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     environment:
       - CHAI_DATABASE_URL=${CHAI_DATABASE_URL:-postgresql://postgres:s3cr3t@db:5432/chai}
       - PGPASSWORD=${CHAI_DB_PASSWORD:-s3cr3t}
-      - CHAI_DATABASE_ADMIN_URL=${CHAI_DATABASE_ADMIN_URL:-postgresql://postgres:s3cr3t@db:5432/postgres}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - CHAI_DATABASE_URL=${CHAI_DATABASE_URL:-postgresql://postgres:s3cr3t@db:5432/chai}
       - PGPASSWORD=${CHAI_DB_PASSWORD:-s3cr3t}
+      - CHAI_DATABASE_ADMIN_URL=${CHAI_DATABASE_ADMIN_URL:-postgresql://postgres:s3cr3t@db:5432/postgres}
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
       dockerfile: ./alembic/Dockerfile
     environment:
       - CHAI_DATABASE_URL=${CHAI_DATABASE_URL:-postgresql://postgres:s3cr3t@db:5432/chai}
-      - CHAI_DATABASE_ADMIN_URL=${CHAI_DATABASE_URL:-postgresql://postgres:s3cr3t@db:5432/postgres}
-      - PGPASSWORD=${CHAI_DB_PASSWORD:-s3cr3t}
+      - CHAI_DATABASE_ADMIN_URL=${CHAI_DATABASE_ADMIN_URL:-postgresql://postgres:s3cr3t@db:5432/postgres}
+      - PGPASSWORD=${PGPASSWORD:-s3cr3t}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
- The alembic service didn't work because it needs `psql` to work, and the Dockerfile was missing an `apt install postgresql`
- I also improved the parsing of the CHAI_DATABASE_URL – previously it was running `psql -h $CHAI_DATABASE_URL` but this shouldn't work because `-h` expects a host only, not the full URL. 
- When instantiating CHAI for the first time, the run_migrations.sh tries to create `chai` database in postgres, but it needs to first access the default postgres db. I fixed the logic so it won't error when trying to do that.